### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,4 +1,6 @@
 name: Jekyll site CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/nba-stats/security/code-scanning/1](https://github.com/conorheffron/nba-stats/security/code-scanning/1)

To fix this issue, the workflow should declare an explicit `permissions` block to restrict the default GITHUB_TOKEN permissions, following least privilege best practices. Since the job only checks out code and builds a Docker container, it only needs read access to repository contents. The best solution is to add a `permissions` block with `contents: read` at the workflow root (before `jobs:`), so it applies to all jobs (there is only one job in this workflow). This change should be made immediately after the `name:` and before the `on:` block in the `.github/workflows/jekyll-docker.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
