### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "nba-stats",
-  "version": "2.7.9",
+  "version": "2.8.0",
   "description": "NBA Player Statistics 2015 - 2023"
 }


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/nba-stats/security/code-scanning/2](https://github.com/conorheffron/nba-stats/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow, specifying the least privilege needed. Since the workflow uses `proof-html` to check HTML files and does not perform any operations changing the repository/PR/issues, it only needs to read repository contents. The best practice is to set `contents: read` at the root of the workflow file, which applies to all jobs. This can be done by adding the `permissions` block right after the `name` and before `on`. The fix involves editing `.github/workflows/proof-html.yml` to add:

```yaml
permissions:
  contents: read
```

on a new line between the first and second line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
